### PR TITLE
Fix macOS installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@
     Mac:
 
     ```bash
-    mkdir -p $HOME/Library/Application Support/OpenSCAD/color-schemes/editor $HOME/Library/Application Support/OpenSCAD/color-schemes/render
+    mkdir -p "$HOME/Library/Application Support/OpenSCAD/color-schemes/editor" "$HOME/Library/Application Support/OpenSCAD/color-schemes/render"
     ```
 
     Windows:
@@ -55,8 +55,8 @@
     Mac:
 
     ```bash
-    ln -s $PWD/dracula.json $HOME/Library/Application Support/OpenSCAD/color-schemes/editor
-    ln -s $PWD/transylvania.json $HOME/Library/Application Support/OpenSCAD/color-schemes/render
+    ln -s "$PWD/dracula.json" "$HOME/Library/Application Support/OpenSCAD/color-schemes/editor"
+    ln -s "$PWD/transylvania.json" "$HOME/Library/Application Support/OpenSCAD/color-schemes/render"
     ```
 
     Windows:


### PR DESCRIPTION
Fixes https://github.com/dracula/openscad/issues/2 .

I'm not sure if the quotes on `"$PWD/dracula.json"` and `"$PWD/transylvania.json"` are redundant because there are no spaces in the paths, but ChatGPT seems to think the quotes are necessary. Maybe it accounts for spaces in whatever the `$PWD` value is holding? I'm not that familiar with shell scripting.